### PR TITLE
Add functionality to the bestiary command

### DIFF
--- a/plugin/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryCommand.java
+++ b/plugin/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryCommand.java
@@ -1,12 +1,12 @@
 package com.playmonumenta.libraryofsouls.bestiary;
 
 import java.text.MessageFormat;
-
-import org.bukkit.ChatColor;
-import org.bukkit.entity.Player;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.playmonumenta.libraryofsouls.LibraryOfSouls;
 import com.playmonumenta.libraryofsouls.Soul;
+import com.playmonumenta.libraryofsouls.SoulEntry;
 import com.playmonumenta.libraryofsouls.SoulsDatabase;
 import com.playmonumenta.libraryofsouls.commands.LibraryOfSoulsCommand;
 
@@ -18,7 +18,20 @@ import dev.jorel.commandapi.arguments.EntitySelectorArgument.EntitySelector;
 import dev.jorel.commandapi.arguments.IntegerArgument;
 import dev.jorel.commandapi.arguments.StringArgument;
 import dev.jorel.commandapi.arguments.TextArgument;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
 
 public class BestiaryCommand {
 	public static void register() {
@@ -91,6 +104,14 @@ public class BestiaryCommand {
 						bestiary.openBestiary(player, null, null, -1);
 					}
 				}))
+			.withSubcommand(new CommandAPICommand("info")
+				.withPermission(CommandPermission.fromString("los.bestiary.info"))
+				.withArguments(new StringArgument("mobLabel").replaceSuggestions(LibraryOfSoulsCommand.LIST_MOBS_FUNCTION))
+				.executesPlayer((sender, args) -> {
+					SoulEntry soul = SoulsDatabase.getInstance().getSoul((String)args[0]);
+					LoreTestInventory inv = new LoreTestInventory(soul, sender);
+					inv.openInventory(sender);
+				}))
 			.withSubcommand(new CommandAPICommand("lore")
 					.withPermission(CommandPermission.fromString("los.bestiary.lore"))
 					.withArguments(new StringArgument("mobLabel").replaceSuggestions(LibraryOfSoulsCommand.LIST_MOBS_FUNCTION))
@@ -99,6 +120,17 @@ public class BestiaryCommand {
 						SoulsDatabase.getInstance().getSoul((String)args[0]).setLore((String)args[1], sender);
 					}))
 			.withSubcommand(new CommandAPICommand("lore")
+				.withPermission(CommandPermission.fromString("los.bestiary.lore"))
+				.withArguments(new StringArgument("mobLabel").replaceSuggestions(LibraryOfSoulsCommand.LIST_MOBS_FUNCTION))
+				.withArguments(new TextArgument("lore"))
+				.executesProxy((sender, args) -> {
+					if (sender.getCallee() instanceof Player) {
+						SoulsDatabase.getInstance().getSoul((String)args[0]).setLore((String)args[1], (Player)sender.getCallee());
+					} else {
+						sender.getCaller().sendMessage("Callee must be instance of Player");
+					}
+				}))
+			.withSubcommand(new CommandAPICommand("lore")
 				.withSubcommand(new CommandAPICommand("clear")
 				.withPermission(CommandPermission.fromString("los.bestiary.lore"))
 				.withArguments(new StringArgument("mobLabel").replaceSuggestions(LibraryOfSoulsCommand.LIST_MOBS_FUNCTION))
@@ -106,5 +138,52 @@ public class BestiaryCommand {
 					SoulsDatabase.getInstance().getSoul((String)args[0]).setLore("", sender);
 				})))
 			.register();
+	}
+
+	private static class LoreTestInventory {
+		public static Inventory inv;
+		private LoreTestInventory(SoulEntry soul, Player player) {
+			inv = Bukkit.createInventory(player, 54);
+			ItemStack loreItem = getLoreItem(soul);
+			for(int i = 0; i < 54; i++) {
+				inv.setItem(i, new ItemStack(Material.BLUE_STAINED_GLASS_PANE));
+			}
+
+			inv.setItem(33, loreItem);
+		}
+
+		public void openInventory(Player player) {
+			player.openInventory(inv);
+		}
+
+		public ItemStack getLoreItem(SoulEntry soul) {
+			String lore = soul.getLore();
+
+			ItemStack loreItem = new ItemStack(Material.BOOK);
+			ItemMeta meta = loreItem.getItemMeta();
+			meta.displayName(Component.text("Lore", NamedTextColor.WHITE).decoration(TextDecoration.ITALIC, false).decoration(TextDecoration.BOLD, true));
+
+			if (lore == null || lore.equals("")) {
+				List<Component> itemLore = new ArrayList<>();
+				itemLore.add(Component.text("This is a bug. Or at the very least, should be.", NamedTextColor.WHITE).decoration(TextDecoration.ITALIC, true));
+
+				meta.lore(itemLore);
+				loreItem.setItemMeta(meta);
+				return loreItem;
+			}
+
+			List<Component> itemLore = new ArrayList<>();
+
+			String[] loreArray = lore.split("~~~");
+
+			for (String a : loreArray) {
+				itemLore.add(Component.text(a, NamedTextColor.WHITE).decoration(TextDecoration.ITALIC, true));
+			}
+
+			meta.lore(itemLore);
+			loreItem.setItemMeta(meta);
+
+			return loreItem;
+		}
 	}
 }


### PR DESCRIPTION
You are now able to run the lore command inside of a command block using execute as a player (for tracking changes), as well as added a new command to let you easily see how lore will look in the bestiary without having to navigate to the page every time. The new lore inventory is rudimentary and only should be used to check how lore will look, and nothing else.