### PR TITLE
Bestiary GUI Bug Fixes (Note: need to check in new artifacts?)

### DIFF
--- a/src/main/java/com/playmonumenta/libraryofsouls/SoulEntry.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/SoulEntry.java
@@ -27,6 +27,7 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
@@ -250,6 +251,12 @@ public class SoulEntry implements Soul, BestiaryEntryInterface {
 			}
 
 			meta.lore(lore);
+
+			// Hide weapon damage, book enchants, and potion effects:
+			meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
+			meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+			meta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
+
 			item.setItemMeta(meta);
 			return item;
 		}

--- a/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryArea.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryArea.java
@@ -18,6 +18,7 @@ import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.Nullable;
@@ -101,6 +102,11 @@ public class BestiaryArea implements BestiaryEntryInterface {
 			Component subtitle = Utils.parseMiniMessage(config.getString("subtitle"));
 			meta.lore(Arrays.asList(subtitle));
 		}
+
+		// Hide weapon damage, book enchants, and potion effects:
+		meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
+		meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+		meta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
 
 		mItem.setItemMeta(meta);
 	}

--- a/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiarySoulInventory.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiarySoulInventory.java
@@ -270,7 +270,7 @@ public class BestiarySoulInventory extends CustomInventory {
 		double armorToughness = 0;
 		double health = vars.hasKey("Health") ? 0.0 + Float.valueOf(vars.getFloat("Health")) : 0.0;
 		double speed = vars.hasKey("MovementSpeed") ? 0.0 + Float.valueOf(vars.getFloat("MovementSpeed")) : 0;
-		double damage = attr.getAttribute(AttributeType.ATTACK_DAMAGE) != null ? attr.getAttribute(AttributeType.ATTACK_DAMAGE).getBase() : 0.0;
+		double damage = attr.getAttribute(AttributeType.ATTACK_DAMAGE) != null ? Math.max(attr.getAttribute(AttributeType.ATTACK_DAMAGE).getBase(), 0.0) : 0.0;
 		double speedScalar = 0;
 		double speedPercent = 1;
 		double bowDamage = 0;
@@ -648,6 +648,7 @@ public class BestiarySoulInventory extends CustomInventory {
 
 		damageMeta.addEnchant(Enchantment.ARROW_INFINITE, 1, true);
 		damageMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+		damageMeta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS);
 
 		damageItem.setItemMeta(damageMeta);
 


### PR DESCRIPTION
- Hide attributes for Bestiary Areas and Bestiary Souls (fixes bug #9123)
- Cap damage stat at minimum 0 (fixes bug #10204)
- Hide potion attributes for damage stat icon (fixes bug #12997)