### PR TITLE
Add display for mob descriptions in bestiary entry and add util commands for managing descriptions 

### DIFF
--- a/src/main/java/com/playmonumenta/libraryofsouls/SoulEntry.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/SoulEntry.java
@@ -268,7 +268,9 @@ public class SoulEntry implements Soul, BestiaryEntryInterface {
 			lore.add(Component.text(BestiarySoulInventory.formatWell(getId().getKey()), NamedTextColor.GRAY).decoration(TextDecoration.ITALIC, false));
 			lore.add(Component.text("Kills: " + BestiaryManager.getKillsForMob(player, this), NamedTextColor.DARK_RED).decoration(TextDecoration.ITALIC, false));
 			if (!mDescription.isEmpty()) {
-				lore.addAll(getDescription());
+				for (Component line : mDescription) {
+					lore.add(line.color(NamedTextColor.DARK_GRAY));
+				}
 			}
 			if (info.allowsAccessTo(InfoTier.STATS)) {
 				lore.add(Component.text("Click for more info!", NamedTextColor.LIGHT_PURPLE).decoration(TextDecoration.ITALIC, false));

--- a/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryCommand.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryCommand.java
@@ -1,7 +1,6 @@
 package com.playmonumenta.libraryofsouls.bestiary;
 
 import com.playmonumenta.libraryofsouls.LibraryOfSouls;
-import com.playmonumenta.libraryofsouls.Soul;
 import com.playmonumenta.libraryofsouls.SoulEntry;
 import com.playmonumenta.libraryofsouls.SoulsDatabase;
 import com.playmonumenta.libraryofsouls.commands.LibraryOfSoulsCommand;
@@ -10,17 +9,13 @@ import dev.jorel.commandapi.CommandAPICommand;
 import dev.jorel.commandapi.CommandPermission;
 import dev.jorel.commandapi.arguments.EntitySelectorArgument;
 import dev.jorel.commandapi.arguments.IntegerArgument;
-import dev.jorel.commandapi.arguments.StringArgument;
 import dev.jorel.commandapi.arguments.TextArgument;
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Item;
@@ -134,6 +129,26 @@ public class BestiaryCommand {
 						} else {
 							ItemStack item = new ItemStack(Material.BOOK);
 							item.lore(soul.getLore());
+							Location location = sender.getLocation();
+							if (!sender.getInventory().addItem(item).isEmpty()) {
+								Item droppedItem = location.getWorld().dropItem(location, item);
+								droppedItem.setPickupDelay(0);
+								droppedItem.setCanMobPickup(false);
+							}
+						}
+					})))
+			.withSubcommand(new CommandAPICommand("description")
+				.withSubcommand(new CommandAPICommand("get")
+					.withPermission(CommandPermission.fromString("los.bestiary.description"))
+					.withArguments(LibraryOfSoulsCommand.mobLabelArg)
+					.executesPlayer((sender, args) -> {
+						String name = args.getByArgument(LibraryOfSoulsCommand.mobLabelArg);
+						SoulEntry soul = SoulsDatabase.getInstance().getSoul(name);
+						if (soul == null) {
+							throw CommandAPI.failWithString("Mob '" + name + "' not found");
+						} else {
+							ItemStack item = new ItemStack(Material.BLAZE_POWDER);
+							item.lore(soul.getDescription());
 							Location location = sender.getLocation();
 							if (!sender.getInventory().addItem(item).isEmpty()) {
 								Item droppedItem = location.getWorld().dropItem(location, item);

--- a/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiarySoulInventory.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiarySoulInventory.java
@@ -468,6 +468,7 @@ public class BestiarySoulInventory extends CustomInventory {
 			effectItem = getEffectItem(effectItem);
 			ItemStack speedItem = getSpeedItem(entityNBT, speed, speedScalar, speedPercent);
 
+			ItemStack descriptionItem = getDescriptionItem(soul);
 			ItemStack loreItem = getLoreItem(soul);
 			ItemStack equipmentPageItem = new ItemStack(Material.LIME_STAINED_GLASS_PANE);
 			ItemMeta meta = equipmentPageItem.getItemMeta();
@@ -477,6 +478,9 @@ public class BestiarySoulInventory extends CustomInventory {
 			_inventory.setItem(11, healthItem);
 			_inventory.setItem(13, armorItem);
 			_inventory.setItem(15, damageItem);
+			if (!soul.getDescription().isEmpty()) {
+				_inventory.setItem(16, descriptionItem);
+			}
 			_inventory.setItem(22, equipmentPageItem);
 			if (!soul.getLore().isEmpty()) {
 				_inventory.setItem(29, speedItem);
@@ -756,6 +760,30 @@ public class BestiarySoulInventory extends CustomInventory {
 		loreItem.setItemMeta(meta);
 
 		return loreItem;
+	}
+
+	public ItemStack getDescriptionItem(SoulEntry soul) {
+		List<Component> description = soul.getDescription();
+		ItemStack descriptionItem = new ItemStack(Material.BLAZE_POWDER);
+		ItemMeta meta = descriptionItem.getItemMeta();
+		meta.displayName(Component.text("Description", NamedTextColor.WHITE, TextDecoration.BOLD).decoration(TextDecoration.ITALIC, false));
+
+		if (description == null || description.isEmpty()) {
+			List<Component> itemDescription = new ArrayList<>();
+			itemDescription.add(Component.text("This is a bug. Or at the very least, should be.", NamedTextColor.WHITE).decoration(TextDecoration.ITALIC, true));
+			meta.lore(itemDescription);
+			descriptionItem.setItemMeta(meta);
+			return descriptionItem;
+		}
+
+		List<Component> itemDescription = new ArrayList<>();
+		for (Component comp : description) {
+			itemDescription.add(comp.color(NamedTextColor.GRAY));
+		}
+
+		meta.lore(itemDescription);
+		descriptionItem.setItemMeta(meta);
+		return descriptionItem;
 	}
 
 	//Legacy function, will be edited once the new boss tags system is implemented


### PR DESCRIPTION
- Added a slot in the mob's bestiary entry page to show its description
- Added /bestiary description get [mob] to get an item with the mob's description for easy editing
