### PR TITLE
"bestiary_display_name"

### DIFF
--- a/src/main/java/com/playmonumenta/libraryofsouls/SoulEntry.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/SoulEntry.java
@@ -511,8 +511,6 @@ public class SoulEntry implements Soul, BestiaryEntryInterface {
 		Component bestiaryDisplayName = null;
 		elem = obj.get("bestiary_display_name");
 		if (elem != null && elem.isJsonPrimitive()) {
-			LibraryOfSouls.getInstance().getLogger().info("display name found");
-			LibraryOfSouls.getInstance().getLogger().info("it is "+elem.getAsString());
 			bestiaryDisplayName = GSON_SERIALIZER.deserialize(elem.getAsString());
 		}
 

--- a/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryArea.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryArea.java
@@ -27,6 +27,7 @@ public class BestiaryArea implements BestiaryEntryInterface {
 	private final @Nullable NamespacedKey mAdvancementKey;
 	private final ItemStack mItem;
 	private final List<BestiaryEntryInterface> mChildren;
+	private final @Nullable String mInventoryName;
 
 	private static final ItemStack NOT_FOUND_ITEM = new ItemStack(Material.PAPER);
 
@@ -85,6 +86,13 @@ public class BestiaryArea implements BestiaryEntryInterface {
 			}
 		} else {
 			mAdvancementKey = null;
+		}
+
+		if (config.contains("inventory_name")) {
+			// lets you skip the Utils.plainText() for the name of the BestiaryAreaInventory
+			mInventoryName = config.getString("inventory_name");
+		} else {
+			mInventoryName = null;
 		}
 
 		if (config.contains("item")) {
@@ -158,5 +166,12 @@ public class BestiaryArea implements BestiaryEntryInterface {
 	/* Only intermediate nodes have children */
 	public List<BestiaryEntryInterface> getBestiaryChildren() {
 		return mChildren;
+	}
+
+	public String getInventoryName() {
+		if (mInventoryName != null) {
+			return mInventoryName;
+		}
+		return Utils.plainText(getBestiaryName());
 	}
 }

--- a/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryArea.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryArea.java
@@ -10,7 +10,9 @@ import java.util.*;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.ConfigurationSection;
@@ -168,10 +170,13 @@ public class BestiaryArea implements BestiaryEntryInterface {
 		return mChildren;
 	}
 
-	public String getInventoryName() {
+	public String getInventoryTitle() {
+		Component component = Component.text("Bestiary: ", NamedTextColor.BLACK);
 		if (mInventoryName != null) {
-			return mInventoryName;
+			component = component.append(GsonComponentSerializer.gson().deserialize(mInventoryName));
+		} else {
+			component = component.append(Component.text(Utils.plainText(getBestiaryName())));
 		}
-		return Utils.plainText(getBestiaryName());
+		return Utils.LEGACY_SERIALIZER.serialize(component);
 	}
 }

--- a/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryArea.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryArea.java
@@ -119,7 +119,7 @@ public class BestiaryArea implements BestiaryEntryInterface {
 	 */
 
 	@Override
-	public Component getName() {
+	public Component getBestiaryName() {
 		return mName;
 	}
 

--- a/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryArea.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryArea.java
@@ -12,7 +12,6 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.ConfigurationSection;

--- a/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryAreaInventory.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryAreaInventory.java
@@ -52,7 +52,7 @@ public class BestiaryAreaInventory extends CustomInventory {
 
 	@SuppressWarnings("deprecation")
 	public BestiaryAreaInventory(Player player, BestiaryArea area, int offset) {
-		super(player, 54, ChatColor.BLACK + "Bestiary: " + Utils.plainText(area.getBestiaryName()));
+		super(player, 54, ChatColor.BLACK + "Bestiary: " + area.getInventoryName());
 		mOffset = offset;
 		mArea = area;
 		mChildren = mArea.getBestiaryChildren();

--- a/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryAreaInventory.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryAreaInventory.java
@@ -49,9 +49,8 @@ public class BestiaryAreaInventory extends CustomInventory {
 	private final BestiaryArea mArea;
 	private final List<BestiaryEntryInterface> mChildren;
 
-	@SuppressWarnings("deprecation")
 	public BestiaryAreaInventory(Player player, BestiaryArea area, int offset) {
-		super(player, 54, ChatColor.BLACK + "Bestiary: " + area.getInventoryName());
+		super(player, 54, area.getInventoryTitle());
 		mOffset = offset;
 		mArea = area;
 		mChildren = mArea.getBestiaryChildren();

--- a/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryAreaInventory.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryAreaInventory.java
@@ -52,7 +52,7 @@ public class BestiaryAreaInventory extends CustomInventory {
 
 	@SuppressWarnings("deprecation")
 	public BestiaryAreaInventory(Player player, BestiaryArea area, int offset) {
-		super(player, 54, ChatColor.BLACK + "Bestiary: " + Utils.plainText(area.getName()));
+		super(player, 54, ChatColor.BLACK + "Bestiary: " + Utils.plainText(area.getBestiaryName()));
 		mOffset = offset;
 		mArea = area;
 		mChildren = mArea.getBestiaryChildren();

--- a/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryAreaInventory.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryAreaInventory.java
@@ -8,7 +8,6 @@ import java.util.List;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;

--- a/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryAreaInventory.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryAreaInventory.java
@@ -3,7 +3,6 @@ package com.playmonumenta.libraryofsouls.bestiary;
 import com.goncalomb.bukkit.mylib.utils.CustomInventory;
 import com.playmonumenta.libraryofsouls.LibraryOfSouls;
 import com.playmonumenta.libraryofsouls.SoulEntry;
-import com.playmonumenta.libraryofsouls.utils.Utils;
 import java.util.ArrayList;
 import java.util.List;
 import net.kyori.adventure.text.Component;

--- a/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryCommand.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryCommand.java
@@ -51,7 +51,7 @@ public class BestiaryCommand {
 					sender.sendMessage(Component.text().append(Component.text(player.getName(), NamedTextColor.BLUE))
 						                   .append(Component.text(" has killed "))
 						                   .append(Component.text(kills + " ", NamedTextColor.GREEN))
-						                   .append(soul.getDisplayName()));
+						                   .append(soul.getBestiaryName()));
 					return kills;
 				}))
 			.withSubcommand(new CommandAPICommand("set")

--- a/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryEntryInterface.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiaryEntryInterface.java
@@ -7,7 +7,7 @@ import org.bukkit.inventory.ItemStack;
 
 public interface BestiaryEntryInterface {
 	/* Name of this bestiary entry for display purposes */
-	Component getName();
+	Component getBestiaryName();
 
 	/* Checks whether the player has permission to open this bestiary entry */
 	boolean canOpenBestiary(Player player);

--- a/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiarySoulEquipmentInventory.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiarySoulEquipmentInventory.java
@@ -34,7 +34,7 @@ public class BestiarySoulEquipmentInventory extends CustomInventory {
 	private int mNextEntry = 40000;
 
 	public BestiarySoulEquipmentInventory(Player player, SoulEntry soul, BestiaryArea soulsParent, List<BestiaryEntryInterface> soulPeers, int soulPeerIndex) {
-		super(player, 54, LegacyComponentSerializer.legacySection().serialize(soul.getDisplayName()) + "'s Equipment");
+		super(player, 54, LegacyComponentSerializer.legacySection().serialize(soul.getBestiaryName()) + "'s Equipment");
 		mSoul = soul;
 		mSoulsParent = soulsParent;
 		mSoulPeers = soulPeers;

--- a/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiarySoulInventory.java
+++ b/src/main/java/com/playmonumenta/libraryofsouls/bestiary/BestiarySoulInventory.java
@@ -260,7 +260,7 @@ public class BestiarySoulInventory extends CustomInventory {
 	private int mNextEntry;
 
 	public BestiarySoulInventory(Player player, SoulEntry soul, BestiaryArea parent, boolean lowerInfoTier, List<BestiaryEntryInterface> peers, int peerIndex) {
-		super(player, 54, LegacyComponentSerializer.legacySection().serialize(blackIfWhite(soul.getDisplayName())));
+		super(player, 54, LegacyComponentSerializer.legacySection().serialize(blackIfWhite(soul.getBestiaryName())));
 
 		mSoul = soul;
 		mParent = parent;


### PR DESCRIPTION
This pull request:
- Adds support for the "bestiary_display_name" property of a mob. This goes in the souls database JSON, and is a property of the mob itself (the SoulEntry), not each one of its history entries (SoulHistoryEntry). Represented as JSON text.
- Adds support for the "inventory_name" property of a bestiary area. This goes in the bestiary_config.yml, and if present replaces the title of the inventory GUI, with "Bestiary: " prefixed to it. Represented as JSON text.
- BestiaryEntryInterface: `getName()` -> `getBestiaryName()` to be separable from `Soul#getName()`
- Also gets rid of a SuppressWarnings(deprecation) for ChatColor